### PR TITLE
Configure and verify whatsapp webhook

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -18,7 +18,7 @@ JWT_EXPIRES_IN=30d
 WHATSAPP_ACCESS_TOKEN=your-whatsapp-access-token
 WHATSAPP_PHONE_NUMBER_ID=your-phone-number-id
 WHATSAPP_BUSINESS_ACCOUNT_ID=your-business-account-id
-WHATSAPP_WEBHOOK_VERIFY_TOKEN=your-webhook-verify-token
+WHATSAPP_WEBHOOK_VERIFY_TOKEN=Verify_MiiMii
 
 # BellBank API
 BELLBANK_CONSUMER_KEY=1c2ea8d82c7661742d2e85a3e82f7819
@@ -67,4 +67,4 @@ RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
 
 # App Configuration
-BASE_URL=https://miimii-app-p8gzu.ondigitalocean.app
+BASE_URL=https://api.chatmiimii.com

--- a/WHATSAPP_WEBHOOK_SETUP.md
+++ b/WHATSAPP_WEBHOOK_SETUP.md
@@ -4,10 +4,47 @@ This guide will help you configure the WhatsApp Business Cloud API webhook for y
 
 ## 🔗 Current Webhook Configuration
 
-Your webhook is already properly implemented with:
-- **Webhook URL**: `https://miimii-app-p8gzu.ondigitalocean.app/webhook/whatsapp`
+Your webhook is properly implemented with:
+- **Webhook URL**: `https://api.chatmiimii.com/webhook/whatsapp`
 - **Verify Token**: `Verify_MiiMii`
 - **Direct Meta API Integration** (not third-party)
+
+## ⚠️ URGENT: Current Issue & Solution
+
+### Issue Identified
+The WhatsApp webhook verification is failing with "403 Forbidden" because:
+1. The production environment has `WHATSAPP_WEBHOOK_VERIFY_TOKEN=your-webhook-verify-token` (placeholder)
+2. But Meta WhatsApp is configured to use `Verify_MiiMii`
+
+### ✅ Solution Steps
+
+#### Step 1: Update DigitalOcean Environment Variables
+1. **Go to**: [DigitalOcean App Platform Dashboard](https://cloud.digitalocean.com/apps)
+2. **Select**: Your MiiMii application
+3. **Go to**: Settings > App-level environment variables
+4. **Find**: `WHATSAPP_WEBHOOK_VERIFY_TOKEN`
+5. **Update value to**: `Verify_MiiMii`
+6. **Save changes**
+
+#### Step 2: Deploy Updated Configuration
+After updating the environment variable:
+1. **Trigger a deployment** (either through git push or manual deploy)
+2. **Wait for deployment** to complete (5-10 minutes)
+
+#### Step 3: Configure Meta Developer Console
+1. **Go to**: https://developers.facebook.com/
+2. **Navigate to**: Your WhatsApp Business App
+3. **Go to**: WhatsApp > Configuration
+4. **Set Webhook URL**: `https://api.chatmiimii.com/webhook/whatsapp`
+5. **Set Verify Token**: `Verify_MiiMii`
+6. **Click "Verify and Save"**
+
+### ✅ Verification Test
+After deployment, test the webhook:
+```bash
+curl -X GET "https://api.chatmiimii.com/webhook/whatsapp?hub.mode=subscribe&hub.verify_token=Verify_MiiMii&hub.challenge=test123"
+# Should return: test123
+```
 
 ## 📋 Prerequisites
 


### PR DESCRIPTION
Update WhatsApp webhook verify token and base URL to resolve webhook verification failures.

The user was unable to verify their WhatsApp webhook URL due to a mismatch between the `Verify_MiiMii` token they were providing to Meta and the `your-webhook-verify-token` placeholder value configured in the application's environment. This PR updates the local `.env.production` file and the `WHATSAPP_WEBHOOK_SETUP.md` documentation to reflect the correct token and base URL, along with detailed instructions for the user to update their DigitalOcean environment variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-59e84a00-b8c8-4b22-a853-0dc74d3ece0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-59e84a00-b8c8-4b22-a853-0dc74d3ece0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>