### PR TITLE
Fix whatsapp oauth token retrieval

### DIFF
--- a/WHATSAPP_TOKEN_ISSUE_DIAGNOSIS.md
+++ b/WHATSAPP_TOKEN_ISSUE_DIAGNOSIS.md
@@ -1,0 +1,169 @@
+# WhatsApp OAuth Token Issue - Diagnosis & Solution
+
+## 🔍 **Issue Analysis**
+
+Based on the error logs and testing, here are the two main issues identified:
+
+### **1. OAuth Error Code 190 - "Invalid OAuth access token"**
+**Root Cause:** Using placeholder Phone Number ID instead of actual WhatsApp Business Phone Number ID
+
+**Current Configuration:**
+- ✅ **Token is VALID** (confirmed by Graph API test)
+- ❌ **Phone Number ID is FAKE** (`123456789012345`)
+- ❌ **Business Account ID is FAKE** (`123456789012345`)
+
+### **2. Onboarding Error - "message.trim is not a function"**
+**Root Cause:** Code was expecting string but receiving object with text property
+**Status:** ✅ **FIXED** - Updated onboarding service to handle message objects properly
+
+---
+
+## 🛠️ **Required Actions**
+
+### **CRITICAL: Get Your Real WhatsApp Business IDs**
+
+You need to replace the placeholder IDs with your actual WhatsApp Business configuration:
+
+#### **Step 1: Find Your WhatsApp Phone Number ID**
+
+1. Go to [Facebook Business Manager](https://business.facebook.com/)
+2. Navigate to **Business Settings**
+3. Click **WhatsApp** > **WhatsApp Business Accounts**
+4. Select your WhatsApp Business Account
+5. Click on **Phone Numbers** tab
+6. Your **Phone Number ID** will be displayed (15-digit number)
+
+#### **Step 2: Find Your WhatsApp Business Account ID (WABA ID)**
+
+1. In the same WhatsApp Business Account section
+2. Look for "Account ID" or "Business Account ID" 
+3. Copy the 15-digit number
+
+#### **Step 3: Update Environment Variables**
+
+Replace these in your DigitalOcean environment variables:
+
+```bash
+# Replace with your ACTUAL IDs
+WHATSAPP_PHONE_NUMBER_ID=your_actual_15_digit_phone_number_id
+WHATSAPP_BUSINESS_ACCOUNT_ID=your_actual_15_digit_business_account_id
+
+# Your token is already correct
+WHATSAPP_ACCESS_TOKEN=EAAXQZBHvBuxgBPN2hO6wDaC2TnX2W2Tq2QnjHEYW9r9qmoCzJBa0fEZBJp8XXpiZBeCx6xqalX5PJ1WrAqENxMAyq3LsuqkPEZBJ4fsPGKTKoHSoOC26hDBhzY68hwLDM0RzE5wNAlJS3bPUZAkRsj2khewZB7l1a7OGZAIrhzhaIlQ6WqZBr95RrQhKGiKwdTaVhX2mLbZCrHnlnk4Mv
+```
+
+---
+
+## 🧪 **Testing Your Configuration**
+
+After updating the IDs, test with this command:
+
+```bash
+curl -X GET \
+  "https://graph.facebook.com/v18.0/YOUR_ACTUAL_PHONE_NUMBER_ID" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+**Expected Success Response:**
+```json
+{
+  "verified_name": "Your Business Name",
+  "display_name": "Your Business Name", 
+  "id": "your_actual_phone_number_id",
+  "status": "CONNECTED"
+}
+```
+
+---
+
+## 📋 **DigitalOcean Environment Setup**
+
+### **Current .digitalocean/app.yaml Configuration:**
+```yaml
+env:
+  - key: WHATSAPP_ACCESS_TOKEN
+    value: ${WHATSAPP_ACCESS_TOKEN}  # ✅ Correct
+  - key: WHATSAPP_PHONE_NUMBER_ID
+    value: ${WHATSAPP_PHONE_NUMBER_ID}  # ❌ Update this
+  - key: WHATSAPP_BUSINESS_ACCOUNT_ID
+    value: ${WHATSAPP_BUSINESS_ACCOUNT_ID}  # ❌ Update this
+```
+
+### **Action Required:**
+1. Go to your DigitalOcean App Platform
+2. Navigate to **Settings** > **Environment Variables**
+3. Update these variables with your real IDs:
+   - `WHATSAPP_PHONE_NUMBER_ID`
+   - `WHATSAPP_BUSINESS_ACCOUNT_ID`
+4. Redeploy your application
+
+---
+
+## 🔧 **Code Fixes Applied**
+
+### **Fixed: Onboarding Service Message Handling**
+
+**Files Updated:**
+- `src/services/onboarding.js`
+
+**Changes Made:**
+```javascript
+// Before (causing error):
+const nameParts = message.trim().split(/\s+/);
+
+// After (fixed):
+const messageText = typeof message === 'string' ? message : (message?.text || '');
+const nameParts = messageText.trim().split(/\s+/);
+```
+
+**Functions Fixed:**
+- `handleNameCollection()` ✅
+- `handlePinSetup()` ✅  
+- `parseKycData()` ✅
+
+---
+
+## 🚀 **Deployment Steps**
+
+1. **Update DigitalOcean Environment Variables** (CRITICAL)
+2. **Redeploy Application**
+3. **Test WhatsApp Webhook:**
+   ```bash
+   curl "https://your-app-url.ondigitalocean.app/webhook/whatsapp?hub.mode=subscribe&hub.verify_token=Verify_MiiMii&hub.challenge=test"
+   ```
+
+4. **Send Test Message to Your WhatsApp Number**
+
+---
+
+## 📞 **Support Information**
+
+**If you still encounter issues after updating the IDs:**
+
+1. **Check Token Permissions:**
+   - Ensure token has `whatsapp_business_messaging` permission
+   - Verify token hasn't expired
+
+2. **Verify Phone Number Status:**
+   - Phone number must be "CONNECTED" status
+   - Check in WhatsApp Manager
+
+3. **Contact Meta Support:**
+   - If phone number shows as disconnected
+   - If token permissions are missing
+
+---
+
+## 🎯 **Quick Fix Summary**
+
+**Immediate Actions:**
+1. ✅ Code issues fixed (message.trim error)
+2. ❌ **UPDATE YOUR PHONE NUMBER ID** (most critical)
+3. ❌ **UPDATE YOUR BUSINESS ACCOUNT ID** 
+4. ❌ **REDEPLOY APPLICATION**
+
+Your WhatsApp access token is valid, but you're using test IDs instead of your real WhatsApp Business configuration. Once you update the IDs, your OAuth errors should disappear!
+
+---
+
+**Need the real IDs?** Go to [Facebook Business Manager](https://business.facebook.com/) → Business Settings → WhatsApp → Phone Numbers

--- a/src/services/onboarding.js
+++ b/src/services/onboarding.js
@@ -104,7 +104,9 @@ class OnboardingService {
   }
 
   async handleNameCollection(user, message) {
-    const nameParts = message.trim().split(/\s+/);
+    // Ensure message is a string before calling trim
+    const messageText = typeof message === 'string' ? message : (message?.text || '');
+    const nameParts = messageText.trim().split(/\s+/);
     
     if (nameParts.length < 2) {
       await whatsappService.sendTextMessage(
@@ -320,7 +322,9 @@ class OnboardingService {
   }
 
   async handlePinSetup(user, message) {
-    const pin = message.trim().replace(/\s+/g, '');
+    // Ensure message is a string before calling trim
+    const messageText = typeof message === 'string' ? message : (message?.text || '');
+    const pin = messageText.trim().replace(/\s+/g, '');
     
     // Validate PIN
     if (!/^\d{4}$/.test(pin)) {
@@ -404,13 +408,15 @@ class OnboardingService {
   }
 
   parseKycData(message) {
-    const lines = message.split('\n').map(line => line.trim()).filter(line => line);
+    // Ensure message is a string before processing
+    const messageText = typeof message === 'string' ? message : (message?.text || '');
+    const lines = messageText.split('\n').map(line => line.trim()).filter(line => line);
     const data = {};
     const missing = [];
 
     // Try to extract date of birth
     const dateRegex = /(\d{1,2})[\/\-\.](\d{1,2})[\/\-\.](\d{4})/;
-    const dateMatch = message.match(dateRegex);
+    const dateMatch = messageText.match(dateRegex);
     if (dateMatch) {
       data.dateOfBirth = `${dateMatch[1].padStart(2, '0')}/${dateMatch[2].padStart(2, '0')}/${dateMatch[3]}`;
     } else {
@@ -419,7 +425,7 @@ class OnboardingService {
 
     // Try to extract gender
     const genderRegex = /\b(male|female|man|woman|m|f)\b/i;
-    const genderMatch = message.match(genderRegex);
+    const genderMatch = messageText.match(genderRegex);
     if (genderMatch) {
       const g = genderMatch[1].toLowerCase();
       data.gender = (g === 'male' || g === 'man' || g === 'm') ? 'male' : 'female';
@@ -429,7 +435,7 @@ class OnboardingService {
 
     // Try to extract BVN
     const bvnRegex = /\b(\d{11})\b/;
-    const bvnMatch = message.match(bvnRegex);
+    const bvnMatch = messageText.match(bvnRegex);
     if (bvnMatch) {
       data.bvn = bvnMatch[1];
     } else {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes `message.trim` error in onboarding service and provides a diagnostic guide for WhatsApp OAuth issues.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `message.trim` error occurred because the `message` parameter in `handleNameCollection`, `handlePinSetup`, and `parseKycData` was sometimes an object (e.g., `{ text: 'Hi' }`) instead of a string, leading to `message.trim is not a function`. The fix ensures that the message content is extracted as a string before attempting to trim it. The OAuth errors were due to incorrect WhatsApp Business IDs, which the new diagnostic guide helps the user resolve by updating environment variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bbce8da-5441-470a-b946-65dd843407fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2bbce8da-5441-470a-b946-65dd843407fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>