### PR TITLE
Handle whatsapp webhook processing errors

### DIFF
--- a/src/services/whatsapp.js
+++ b/src/services/whatsapp.js
@@ -930,4 +930,5 @@ To get started, please complete your KYC by saying "Start KYC" or send your ID d
    }
 }
 
-module.exports = WhatsAppService;
+// Export an instance of the service instead of the class
+module.exports = new WhatsAppService();


### PR DESCRIPTION
Fix `whatsappService.parseWebhookMessage is not a function` error by exporting an instance of `WhatsAppService`.

---
<a href="https://cursor.com/background-agent?bcId=bc-aafdbfe4-eadb-4369-bd9a-4ddd361a5563">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aafdbfe4-eadb-4369-bd9a-4ddd361a5563">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

