### PR TITLE
Investigate whatsapp webhook processing errors

### DIFF
--- a/src/services/whatsapp.js
+++ b/src/services/whatsapp.js
@@ -930,4 +930,4 @@ To get started, please complete your KYC by saying "Start KYC" or send your ID d
    }
 }
 
-module.exports = WhatsAppService;
+module.exports = new WhatsAppService();


### PR DESCRIPTION
Export WhatsAppService as an instance to resolve "parseWebhookMessage is not a function" errors.

The `WhatsAppService` was exported as a class constructor, while other services in the project are exported as instances. This caused `whatsappService` to be the class itself, not an object with callable methods, leading to the `is not a function` error when methods like `parseWebhookMessage` were invoked.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe64b797-da78-4860-b478-f30f420494f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe64b797-da78-4860-b478-f30f420494f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

