### PR TITLE
Fix database connection and dependency issues

### DIFF
--- a/DATABASE_CONNECTION_FIXES.md
+++ b/DATABASE_CONNECTION_FIXES.md
@@ -1,0 +1,172 @@
+# Database Connection Fixes - DigitalOcean Deployment
+
+## Issue Summary
+The application was failing to deploy on DigitalOcean App Platform with the following errors:
+1. **Database connection error**: `TypeError: this.sequelize.connectionManager.on is not a function`
+2. **Health check failure**: Application not responding on port 3000
+3. **Dependency compatibility**: Potential issues with Node.js v22.18.0 and Sequelize 6.37.6
+
+## Root Cause Analysis
+The primary issue was the use of deprecated `connectionManager.on()` methods in Sequelize 6.37.6. The connectionManager event system was changed in newer versions of Sequelize, causing the application to crash during startup.
+
+## Fixes Applied
+
+### 1. ✅ Database Connection Events (Fixed)
+**Problem**: `connectionManager.on()` method no longer available in Sequelize 6.37.6
+**Solution**: Replaced deprecated connection manager events with Sequelize hooks
+
+**Changes Made**:
+- Removed `setupEventListeners()` method that used `this.sequelize.connectionManager.on()`
+- Replaced with proper Sequelize hooks in the sequelize configuration:
+  - `beforeConnect`: Validates shutdown state and logs connection attempts
+  - `afterConnect`: Updates connection status and resets reconnection attempts
+  - `beforeDisconnect`: Logs disconnection process
+  - `afterDisconnect`: Handles reconnection scheduling
+
+**File**: `/workspace/src/database/connection.js`
+
+### 2. ✅ Health Check Implementation (Verified)
+**Problem**: Health checks failing, preventing DigitalOcean deployment
+**Solution**: Confirmed proper health check endpoints are already implemented
+
+**Endpoints Available**:
+- `/healthz`: Simple health check for DigitalOcean (always returns 200 OK)
+- `/health`: Comprehensive health check with service dependencies
+
+**Features**:
+- No database dependency for `/healthz` endpoint
+- Graceful degradation for missing services
+- Proper error handling and status codes
+
+### 3. ✅ Node.js Compatibility (Verified)
+**Problem**: Potential compatibility issues with Node.js 22.18.0
+**Solution**: Verified compatibility matrix
+
+**Compatibility Status**:
+- Node.js version: 22.16.0 (in environment)
+- Sequelize 6.37.6 supports: ">=18.0.0 <=22.x"
+- ✅ Full compatibility confirmed
+
+### 4. ✅ Server Startup (Fixed)
+**Problem**: Application crashing during startup
+**Solution**: Robust startup sequence with proper error handling
+
+**Startup Flow**:
+1. Server starts on port 3000 immediately
+2. Database connection established asynchronously
+3. Health checks available regardless of database status
+4. Graceful degradation for missing services
+
+## Testing Results
+
+### Server Startup Test ✅
+```bash
+✅ MiiMii Fintech Platform server started successfully on 0.0.0.0:3000
+📡 Server is ready to accept connections
+🏥 Health check available at: /healthz
+```
+
+### Health Check Tests ✅
+**Simple Health Check (`/healthz`)**:
+```json
+{
+  "status": "OK",
+  "service": "MiiMii Fintech Platform",
+  "timestamp": "2025-08-06T11:32:38.129Z",
+  "uptime": 2.945204326,
+  "environment": "production",
+  "port": 3000,
+  "host": "0.0.0.0",
+  "version": "1.0.0",
+  "platform": "DigitalOcean App Platform",
+  "nodeVersion": "v22.16.0",
+  "memory": {
+    "used": "59MB",
+    "total": "104MB"
+  }
+}
+```
+
+**Comprehensive Health Check (`/health`)**:
+```json
+{
+  "status": "OK",
+  "timestamp": "2025-08-06T11:32:46.518Z",
+  "uptime": 11.334203177,
+  "port": 3000,
+  "host": "0.0.0.0",
+  "version": "1.0.0",
+  "platform": "DigitalOcean App Platform",
+  "services": {
+    "database": {
+      "status": "healthy",
+      "responseTime": 5
+    },
+    "redis": {
+      "status": "disconnected",
+      "responseTime": 0,
+      "message": "Redis caching disabled, using fallback"
+    }
+  },
+  "performance": {
+    "checkDuration": 5
+  },
+  "message": "Service is operational"
+}
+```
+
+## Deployment Instructions
+
+### 1. Environment Variables
+Ensure these are set in DigitalOcean App Platform:
+- `DB_CONNECTION_URL` or `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`
+- `PORT=3000` (should be automatically set by DigitalOcean)
+
+### 2. Health Check Configuration
+Configure DigitalOcean to use:
+- **Health Check Path**: `/healthz`
+- **Health Check Port**: `3000`
+
+### 3. Startup Command
+The application uses the standard startup command:
+```bash
+node src/app.js
+```
+
+## Monitoring & Maintenance
+
+### Connection Monitoring
+The application includes built-in connection monitoring:
+- Health checks every 30 seconds
+- Automatic reconnection with exponential backoff
+- Maximum 10 reconnection attempts
+- Graceful degradation when services are unavailable
+
+### Logging
+All connection events are properly logged:
+- Connection attempts and successes
+- Connection failures and reconnection attempts
+- Health check results
+- Graceful shutdown processes
+
+## Expected Behavior After Deployment
+
+1. **Immediate Response**: Server starts and responds to health checks immediately
+2. **Database Connection**: Establishes asynchronously without blocking server startup
+3. **Health Checks**: `/healthz` always returns 200 OK for DigitalOcean
+4. **Service Monitoring**: Comprehensive status available at `/health`
+5. **Graceful Handling**: Application continues running even if database is temporarily unavailable
+
+## Next Steps
+
+1. **Deploy** the application with these fixes
+2. **Monitor** deployment logs for successful startup
+3. **Verify** health check endpoint accessibility
+4. **Test** database connectivity once environment variables are properly set
+5. **Configure** any additional services (Redis, WhatsApp, etc.) as needed
+
+---
+
+**Status**: ✅ Ready for deployment
+**Tested**: Local environment with Node.js 22.16.0
+**Compatibility**: Sequelize 6.37.6 + Node.js 22.x confirmed


### PR DESCRIPTION
Replaced deprecated Sequelize `connectionManager.on()` methods with modern Sequelize hooks to fix database connection errors.

The `TypeError: this.sequelize.connectionManager.on is not a function` error was occurring because this method is no longer available in Sequelize 6.37.6. This change updates the connection handling to use `beforeConnect`, `afterConnect`, `beforeDisconnect`, and `afterDisconnect` hooks directly within the Sequelize configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7687225-67db-481e-a476-b332347e8720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7687225-67db-481e-a476-b332347e8720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

