### PR TITLE
Process whatsapp message status updates

### DIFF
--- a/src/services/whatsapp.js
+++ b/src/services/whatsapp.js
@@ -10,6 +10,7 @@ class WhatsAppService {
     this.phoneNumberId = whatsappConfig.phoneNumberId;
     this.baseURL = `https://graph.facebook.com/v18.0/${this.phoneNumberId}`;
     this.verifyToken = whatsappConfig.webhookVerifyToken;
+    this.axiosConfig = axiosConfig;
   }
 
   /**
@@ -153,9 +154,9 @@ class WhatsAppService {
         `${this.baseURL}/messages`,
         payload,
         {
-          ...axiosConfig,
+          ...this.axiosConfig,
           headers: {
-            ...axiosConfig.headers,
+            ...this.axiosConfig.headers,
             'Authorization': `Bearer ${this.accessToken}`,
             'Content-Type': 'application/json'
           }
@@ -408,9 +409,9 @@ class WhatsAppService {
       const response = await axios.get(
         `https://graph.facebook.com/v18.0/${formattedNumber}?fields=profile`,
         {
-          ...axiosConfig,
+          ...this.axiosConfig,
           headers: {
-            ...axiosConfig.headers,
+            ...this.axiosConfig.headers,
             'Authorization': `Bearer ${this.accessToken}`
           }
         }
@@ -466,9 +467,9 @@ class WhatsAppService {
           message_id: messageId
         },
         {
-          ...axiosConfig,
+          ...this.axiosConfig,
           headers: {
-            ...axiosConfig.headers,
+            ...this.axiosConfig.headers,
             'Authorization': `Bearer ${this.accessToken}`,
             'Content-Type': 'application/json'
           }
@@ -510,9 +511,9 @@ class WhatsAppService {
       const mediaResponse = await axios.get(
         `https://graph.facebook.com/v18.0/${mediaId}`,
         {
-          ...axiosConfig,
+          ...this.axiosConfig,
           headers: {
-            ...axiosConfig.headers,
+            ...this.axiosConfig.headers,
             'Authorization': `Bearer ${this.accessToken}`
           }
         }
@@ -522,9 +523,9 @@ class WhatsAppService {
 
       // Download the actual media
       const downloadResponse = await axios.get(mediaUrl, {
-        ...axiosConfig,
+        ...this.axiosConfig,
         headers: {
-          ...axiosConfig.headers,
+          ...this.axiosConfig.headers,
           'Authorization': `Bearer ${this.accessToken}`
         },
         responseType: 'stream'
@@ -584,9 +585,9 @@ class WhatsAppService {
       const response = await axios.get(
         `https://graph.facebook.com/v18.0/${this.phoneNumberId}`,
         {
-          ...axiosConfig,
+          ...this.axiosConfig,
           headers: {
-            ...axiosConfig.headers,
+            ...this.axiosConfig.headers,
             'Authorization': `Bearer ${this.accessToken}`
           }
         }


### PR DESCRIPTION
Initializes `this.axiosConfig` and standardizes its usage in `WhatsAppService` to fix 'Cannot read properties of undefined (reading 'headers')' errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-e97040c6-aae1-4e45-957a-fe9253af628a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e97040c6-aae1-4e45-957a-fe9253af628a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

